### PR TITLE
fix: resolve SARIF upload permissions issue in CI/CD

### DIFF
--- a/.github/workflows/terraform-module.yml
+++ b/.github/workflows/terraform-module.yml
@@ -8,6 +8,11 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 env:
   TF_VERSION: '1.9.0'
   TF_DOCS_VERSION: 'v0.17.0'
@@ -53,6 +58,7 @@ jobs:
 
     - name: Run Checkov
       run: |
+        echo "🔒 Executando análise de segurança com Checkov..."
         checkov --framework terraform \
                 --check CKV_AWS_79,CKV_AWS_130,CKV_AWS_135,CKV_AWS_83,CKV_AWS_24 \
                 --directory . \
@@ -60,12 +66,41 @@ jobs:
                 --output sarif \
                 --output-file-path console,checkov-report.sarif \
                 --soft-fail
+        
+        echo ""
+        echo "📊 Resumo da análise de segurança:"
+        if [ -f "checkov-report.sarif" ]; then
+          echo "✅ Arquivo SARIF gerado: checkov-report.sarif"
+        else
+          echo "⚠️  Arquivo SARIF não foi gerado"
+        fi
 
     - name: Upload Checkov SARIF file
       uses: github/codeql-action/upload-sarif@v3
-      if: always()
+      if: always() && github.event_name != 'pull_request'
+      continue-on-error: true
       with:
         sarif_file: checkov-report.sarif
+
+    - name: Checkov Results Summary
+      if: always()
+      run: |
+        echo "📋 RESUMO DOS RESULTADOS CHECKOV"
+        echo "================================"
+        echo ""
+        if [ -f "checkov-report.sarif" ]; then
+          echo "✅ Análise de segurança concluída"
+          echo "📁 Arquivo SARIF disponível para Code Scanning"
+        else
+          echo "⚠️  Arquivo SARIF não disponível"
+        fi
+        echo ""
+        echo "🎯 Verificações realizadas:"
+        echo "   • CKV_AWS_79: VPC Default Security Group"
+        echo "   • CKV_AWS_130: VPC Subnets IP Assignment"
+        echo "   • CKV_AWS_135: VPC Flow Logs"
+        echo "   • CKV_AWS_83: VPC Endpoints"
+        echo "   • CKV_AWS_24: Security Groups SSH Access"
 
   test:
     name: 'Test'

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ AWS_ACCESS_KEY_ID     # Sua Access Key ID da AWS
 AWS_SECRET_ACCESS_KEY # Sua Secret Access Key da AWS
 ```
 
+### Configuração Opcional: Code Scanning
+
+Para habilitar o upload dos resultados do Checkov para a aba "Security" do GitHub:
+
+1. Acesse: `Settings` → `Code security and analysis`
+2. Habilite: `Code scanning` → `Set up`
+3. Escolha: `GitHub Actions` → `Configure`
+
+> **Nota**: Se o Code scanning não estiver habilitado, a pipeline continuará funcionando normalmente, apenas o upload do SARIF será ignorado.
+
 ### Como Obter Credenciais AWS
 
 #### Opção 1: IAM User (Recomendado para CI/CD)


### PR DESCRIPTION
✅ Added security-events: write permission to workflow ✅ Made SARIF upload optional with continue-on-error ✅ Skip SARIF upload for pull requests (not supported) ✅ Added Checkov Results Summary step for better visibility 📚 Updated README with Code Scanning setup instructions 🔒 Enhanced security workflow resilience

Resolves: 'Resource not accessible by integration' error Graceful degradation when Code Scanning is not enabled